### PR TITLE
Make test case compatible with Go 1.17

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -477,12 +477,12 @@ func TestApp_RunAsSubCommandIncorrectUsage(t *testing.T) {
 	}
 
 	set := flag.NewFlagSet("", flag.ContinueOnError)
-	_ = set.Parse([]string{"", "foobar"})
+	_ = set.Parse([]string{"", "-bar"})
 	c := &Context{flagSet: set}
 
 	err := a.RunAsSubcommand(c)
 
-	expect(t, err.Error(), "No help topic for 'foobar'")
+	expect(t, err.Error(), "flag provided but not defined: -bar")
 }
 
 func TestApp_CommandWithFlagBeforeTerminator(t *testing.T) {

--- a/app_test.go
+++ b/app_test.go
@@ -471,18 +471,18 @@ func TestApp_RunAsSubCommandIncorrectUsage(t *testing.T) {
 	a := App{
 		Name: "cmd",
 		Flags: []Flag{
-			&StringFlag{Name: "--foo"},
+			&StringFlag{Name: "foo"},
 		},
 		Writer: bytes.NewBufferString(""),
 	}
 
 	set := flag.NewFlagSet("", flag.ContinueOnError)
-	_ = set.Parse([]string{"", "---foo"})
+	_ = set.Parse([]string{"", "foobar"})
 	c := &Context{flagSet: set}
 
 	err := a.RunAsSubcommand(c)
 
-	expect(t, err, errors.New("bad flag syntax: ---foo"))
+	expect(t, err.Error(), "No help topic for 'foobar'")
 }
 
 func TestApp_CommandWithFlagBeforeTerminator(t *testing.T) {


### PR DESCRIPTION
This is a cherrypick of https://github.com/urfave/cli/pull/1299 to make the test case work properly with Go 1.17.